### PR TITLE
Feature: add support for WMS tile layers.

### DIFF
--- a/src/components/TileLayer.svelte
+++ b/src/components/TileLayer.svelte
@@ -7,6 +7,7 @@
     const {getMap} = getContext(L);
 
     export let url;
+    export let wms = false;
     export let opacity = 1.0;
     export let zIndex = 1;
     export let options = {};
@@ -19,7 +20,7 @@
 
     $: {
         if (!tileLayer) {
-            tileLayer = L.tileLayer(url, options).addTo(getMap());
+            tileLayer = (!wms ? L.tileLayer(url, options) : L.tileLayer.WMS(url, options)).addTo(getMap());
             eventBridge = new EventBridge(tileLayer, dispatch, events);
         }
         tileLayer.setUrl(url);

--- a/src/pages/components/TileLayer.md
+++ b/src/pages/components/TileLayer.md
@@ -32,10 +32,11 @@
 See https://leafletjs.com/reference-1.7.1.html#tilelayer
 
 ```properties
-url     | Tile layer URL template.      | String
-opacity | Opacity of the tiles.         | Number(1.0)
-zIndex  | Explicit zIndex of the layer. | Number(1)
-options | Options.                      | Object(undefined)
+url     | Tile layer URL template.                                      | String
+wms     | If true, the layer will be created using `L.tileLayer.WMS()`. | Boolean
+opacity | Opacity of the tiles.                                         | Number(1.0)
+zIndex  | Explicit zIndex of the layer.                                 | Number(1)
+options | Options.                                                      | Object(undefined)
 ```
 
 ## Methods


### PR DESCRIPTION
As discussed in #7 , this PR should add support to create tile layers using `L.tileLayer.WMS()`. The [function signature of this constructor](https://leafletjs.com/reference-1.7.1.html#tilelayer) is identical to `L.tileLayer()` so I have simply added an additional optional argument called `wms`, which when `true` causes the component to use the alternative constructor. As far as I can tell there are no other constructors which could require such support.

I have also updated the docs. I haven't bumped the version, and would appreciate feedback/support on testing prior to merge.