### PR TITLE
Update documentation links to use latest Leaflet version

### DIFF
--- a/src/pages/components/Circle.md
+++ b/src/pages/components/Circle.md
@@ -31,7 +31,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#circlemarker
+See https://leafletjs.com/reference.html#circlemarker
 
 ```properties
 latLngs     | Geographical points.    | LatLng[]
@@ -53,4 +53,4 @@ options     | Options.                | Object(undefined)
 
 | Name        | Description |
 |-------------|-------------|
-| getCircle() | Returns the underlying Leaflet `Circle` object instance. See https://leafletjs.com/reference-1.7.1.html#circle |
+| getCircle() | Returns the underlying Leaflet `Circle` object instance. See https://leafletjs.com/reference.html#circle |

--- a/src/pages/components/CircleMarker.md
+++ b/src/pages/components/CircleMarker.md
@@ -39,7 +39,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#circlemarker
+See https://leafletjs.com/reference.html#circlemarker
 
 ```properties
 latLngs     | Geographical points.    | LatLng[]
@@ -61,4 +61,4 @@ options     | Options.                | Object(undefined)
 
 | Name              | Description |
 |-------------------|-------------|
-| getCircleMarker() | Returns the underlying Leaflet `CircleMarker` object instance. See https://leafletjs.com/reference-1.7.1.html#circlemarker |
+| getCircleMarker() | Returns the underlying Leaflet `CircleMarker` object instance. See https://leafletjs.com/reference.html#circlemarker |

--- a/src/pages/components/DivIcon.md
+++ b/src/pages/components/DivIcon.md
@@ -42,7 +42,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#divicon
+See https://leafletjs.com/reference.html#divicon
 
 ```properties
 options        | Options.            | Object(undefined)
@@ -52,4 +52,4 @@ options        | Options.            | Object(undefined)
 
 | Name      | Description |
 |-----------|-------------|
-| getIcon() | Returns the underlying Leaflet `Icon` object instance. See https://leafletjs.com/reference-1.7.1.html#icon |
+| getIcon() | Returns the underlying Leaflet `Icon` object instance. See https://leafletjs.com/reference.html#icon |

--- a/src/pages/components/GeoJSON.md
+++ b/src/pages/components/GeoJSON.md
@@ -37,7 +37,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#geojson
+See https://leafletjs.com/reference.html#geojson
 
 ```properties
 url     | URL to GeoJSON file. | String
@@ -48,4 +48,4 @@ options | Options.             | Object(undefined)
 
 | Name          | Description |
 |---------------|-------------|
-| getGeoJSON() | Returns the underlying Leaflet `GeoJSON` object instance. See https://leafletjs.com/reference-1.7.1.html#geojson |
+| getGeoJSON() | Returns the underlying Leaflet `GeoJSON` object instance. See https://leafletjs.com/reference.html#geojson |

--- a/src/pages/components/Icon.md
+++ b/src/pages/components/Icon.md
@@ -39,7 +39,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#icon
+See https://leafletjs.com/reference.html#icon
 
 ```properties
 options        | Options.            | Object(undefined)
@@ -49,4 +49,4 @@ options        | Options.            | Object(undefined)
 
 | Name      | Description |
 |-----------|-------------|
-| getIcon() | Returns the underlying Leaflet `Icon` object instance. See https://leafletjs.com/reference-1.7.1.html#icon |
+| getIcon() | Returns the underlying Leaflet `Icon` object instance. See https://leafletjs.com/reference.html#icon |

--- a/src/pages/components/ImageOverlay.md
+++ b/src/pages/components/ImageOverlay.md
@@ -34,7 +34,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#imageoverlay
+See https://leafletjs.com/reference.html#imageoverlay
 
 ```properties
 imageUrl | URL to image file.            | String
@@ -47,4 +47,4 @@ options  | Options.                      | Object(undefined)
 
 | Name          | Description |
 |---------------|-------------|
-| getImageOverlay() | Returns the underlying Leaflet `ImageOverlay` object instance. See https://leafletjs.com/reference-1.7.1.html#imageoverlay |
+| getImageOverlay() | Returns the underlying Leaflet `ImageOverlay` object instance. See https://leafletjs.com/reference.html#imageoverlay |

--- a/src/pages/components/LeafletMap.md
+++ b/src/pages/components/LeafletMap.md
@@ -29,11 +29,11 @@
 
 ## Properties
 ```properties
-options | Options. See https://leafletjs.com/reference-1.7.1.html#map-option | Object(undefined)
+options | Options. See https://leafletjs.com/reference.html#map-option | Object(undefined)
 ```
 
 ## Methods
 
 | Name     | Description |
 |----------|-------------|
-| getMap() | Returns the underlying Leaflet `Map` object instance. See https://leafletjs.com/reference-1.7.1.html#map-factory |
+| getMap() | Returns the underlying Leaflet `Map` object instance. See https://leafletjs.com/reference.html#map-factory |

--- a/src/pages/components/Marker.md
+++ b/src/pages/components/Marker.md
@@ -29,7 +29,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#marker
+See https://leafletjs.com/reference.html#marker
 
 ```properties
 latLng         | Geographical point. | LatLng
@@ -45,4 +45,4 @@ options        | Options.            | Object(undefined)
 
 | Name        | Description |
 |-------------|-------------|
-| getMarker() | Returns the underlying Leaflet `Marker` object instance. See https://leafletjs.com/reference-1.7.1.html#marker |
+| getMarker() | Returns the underlying Leaflet `Marker` object instance. See https://leafletjs.com/reference.html#marker |

--- a/src/pages/components/Polygon.md
+++ b/src/pages/components/Polygon.md
@@ -33,7 +33,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#polygon
+See https://leafletjs.com/reference.html#polygon
 
 ```properties
 latLngs     | Geographical points.    | LatLng[]
@@ -55,4 +55,4 @@ options     | Options.                | Object(undefined)
 
 | Name          | Description |
 |---------------|-------------|
-| getPolygon() | Returns the underlying Leaflet `Polygon` object instance. See https://leafletjs.com/reference-1.7.1.html#polygon |
+| getPolygon() | Returns the underlying Leaflet `Polygon` object instance. See https://leafletjs.com/reference.html#polygon |

--- a/src/pages/components/Polyline.md
+++ b/src/pages/components/Polyline.md
@@ -36,7 +36,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#polyline
+See https://leafletjs.com/reference.html#polyline
 
 ```properties
 latLngs    | Geographical points.    | LatLng[]
@@ -54,4 +54,4 @@ options    | Options.                | Object(undefined)
 
 | Name          | Description |
 |---------------|-------------|
-| getPolyline() | Returns the underlying Leaflet `Polyline` object instance. See https://leafletjs.com/reference-1.7.1.html#polyline |
+| getPolyline() | Returns the underlying Leaflet `Polyline` object instance. See https://leafletjs.com/reference.html#polyline |

--- a/src/pages/components/Popup.md
+++ b/src/pages/components/Popup.md
@@ -42,7 +42,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#popup
+See https://leafletjs.com/reference.html#popup
 
 ```properties
 options        | Options.            | Object(undefined)
@@ -52,4 +52,4 @@ options        | Options.            | Object(undefined)
 
 | Name       | Description |
 |------------|-------------|
-| getPopup() | Returns the underlying Leaflet `Popup` object instance. See https://leafletjs.com/reference-1.7.1.html#popup |
+| getPopup() | Returns the underlying Leaflet `Popup` object instance. See https://leafletjs.com/reference.html#popup |

--- a/src/pages/components/Rectangle.md
+++ b/src/pages/components/Rectangle.md
@@ -35,7 +35,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#rectangle
+See https://leafletjs.com/reference.html#rectangle
 
 ```properties
 latLngBounds | Geographical bounds.    | LatLngBounds
@@ -57,4 +57,4 @@ options      | Options.                | Object(undefined)
 
 | Name           | Description |
 |----------------|-------------|
-| getRectangle() | Returns the underlying Leaflet `Rectangle` object instance. See https://leafletjs.com/reference-1.7.1.html#rectangle |
+| getRectangle() | Returns the underlying Leaflet `Rectangle` object instance. See https://leafletjs.com/reference.html#rectangle |

--- a/src/pages/components/ScaleControl.md
+++ b/src/pages/components/ScaleControl.md
@@ -33,7 +33,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#control-scale
+See https://leafletjs.com/reference.html#control-scale
 
 ```properties
 position | Position. | String('topright')
@@ -44,4 +44,4 @@ options  | Options.  | Object(undefined)
 
 | Name              | Description |
 |-------------------|-------------|
-| getScaleControl() | Returns the underlying Leaflet `Control.Scale` object instance. See https://leafletjs.com/reference-1.7.1.html#control-scale |
+| getScaleControl() | Returns the underlying Leaflet `Control.Scale` object instance. See https://leafletjs.com/reference.html#control-scale |

--- a/src/pages/components/TileLayer-WMS.md
+++ b/src/pages/components/TileLayer-WMS.md
@@ -38,7 +38,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#tilelayer-wms
+See https://leafletjs.com/reference.html#tilelayer-wms
 
 ```properties
 url     | Tile layer URL template.                                      | String
@@ -52,4 +52,4 @@ options | Options.                                                      | Object
 
 | Name           | Description |
 |----------------|-------------|
-| getTileLayer() | Returns the underlying Leaflet `TileLayer.WMS` object instance. See https://leafletjs.com/reference-1.7.1.html#tilelayer |
+| getTileLayer() | Returns the underlying Leaflet `TileLayer.WMS` object instance. See https://leafletjs.com/reference.html#tilelayer |

--- a/src/pages/components/TileLayer.md
+++ b/src/pages/components/TileLayer.md
@@ -29,7 +29,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#tilelayer
+See https://leafletjs.com/reference.html#tilelayer
 
 ```properties
 url     | Tile layer URL template.                                      | String
@@ -43,4 +43,4 @@ options | Options.                                                      | Object
 
 | Name           | Description |
 |----------------|-------------|
-| getTileLayer() | Returns the underlying Leaflet `TileLayer` object instance. See https://leafletjs.com/reference-1.7.1.html#tilelayer |
+| getTileLayer() | Returns the underlying Leaflet `TileLayer` object instance. See https://leafletjs.com/reference.html#tilelayer |

--- a/src/pages/components/Tooltip.md
+++ b/src/pages/components/Tooltip.md
@@ -35,7 +35,7 @@
 
 ## Properties
 
-See https://leafletjs.com/reference-1.7.1.html#tooltip
+See https://leafletjs.com/reference.html#tooltip
 
 ```properties
 options        | Options.            | Object(undefined)
@@ -45,4 +45,4 @@ options        | Options.            | Object(undefined)
 
 | Name         | Description |
 |--------------|-------------|
-| getTooltip() | Returns the underlying Leaflet `Tooltip` object instance. See https://leafletjs.com/reference-1.7.1.html#tooltip |
+| getTooltip() | Returns the underlying Leaflet `Tooltip` object instance. See https://leafletjs.com/reference.html#tooltip |


### PR DESCRIPTION
This PR fixes all links in the doc to point to the latest version of Leaflet's documentation.
