### PR TITLE
Use GeoJSON object as input 

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "svelte": "^3.52.0"
   },
   "dependencies": {
-    "axios": "^1.1.3",
     "leaflet": "^1.9.2"
   },
   "keywords": [

--- a/src/components/GeoJSON.svelte
+++ b/src/components/GeoJSON.svelte
@@ -1,13 +1,12 @@
 <script>
     import {createEventDispatcher, getContext, onDestroy, setContext} from 'svelte';
     import L from 'leaflet';
-    import axios from 'axios';
 
     import EventBridge from '../lib/EventBridge';
 
     const {getMap} = getContext(L);
 
-    export let url;
+    export let data;
     export let options = {};
     export let events = [];
 
@@ -25,11 +24,10 @@
             geojson = L.geoJSON(null, options).addTo(getMap());
             eventBridge = new EventBridge(geojson, dispatch, events);
         }
-        axios.get(url)
-            .then(result => {
-                geojson.clearLayers();
-                geojson.addData(result.data);
-            });
+        if (data) {
+            geojson.clearLayers();
+            geojson.addData(data);
+        }
     }
 
     onDestroy(() => {

--- a/src/pages/components/GeoJSON.md
+++ b/src/pages/components/GeoJSON.md
@@ -3,7 +3,15 @@
 ## Basic usage
 ```example height:400
 <script>
+    import { onMount } from 'svelte';
     import {LeafletMap, GeoJSON, TileLayer} from 'svelte-leafletjs';
+
+    let geoJsonData
+
+    onMount(async () => {
+        const response = await fetch('static/example.geojson')
+        geoJsonData = await response.json()
+    });
 
     const mapOptions = {
         center: [1.250111, 103.830933],
@@ -30,7 +38,7 @@
 <div class="example">
     <LeafletMap options={mapOptions}>
         <TileLayer url={tileUrl} options={tileLayerOptions}/>
-        <GeoJSON url="static/example.geojson" options={geoJsonOptions}/>
+        <GeoJSON data={geoJsonData} options={geoJsonOptions}/>
     </LeafletMap>
 </div>
 ```
@@ -40,8 +48,8 @@
 See https://leafletjs.com/reference-1.7.1.html#geojson
 
 ```properties
-url     | URL to GeoJSON file. | String
-options | Options.             | Object(undefined)
+data    | GeoJSON object | Object(undefined)
+options | Options.       | Object(undefined)
 ```
 
 ## Methods


### PR DESCRIPTION
As discussed in #20 here is an attempt to move the loading of a GeoJSON file outside of the library. Haven't fully tested this in all possible scenarios, but maybe it's a good option and have less dependencies.

This would also make it possible to use generated GeoJSON.