### PR TITLE
Add svelte condition to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,10 @@
     "src/extensions",
     "src/lib",
     "dist"
-  ]
+  ],
+  "exports": {
+    ".": {
+     "svelte": "./dist/index.mjs"
+    }
+  }
 }


### PR DESCRIPTION
fixes: #34 
Maybe also fixes: #6

I tested this with a local project, the error mentioned in #34 indeed goes away. If I use `"svelte": "./dist/index.js"`:

```
"Marker" is not exported by "../svelte-leaflet/dist/index.js", imported by "js/src/bkn/Map.svelte".
file: /Users/jieter/workspace/obs-b/js/src/bkn/Map.svelte:3:36
1: <script lang="ts">
2:     import { onMount } from 'svelte';
3:     import { LeafletMap, TileLayer, Marker, GeoJSON } from 'svelte-leafletjs';
                                       ^
4:     import type { Point } from './types.d';
```